### PR TITLE
Revised Association README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ Things you may want to cover:
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|username|string|null: false|
+|name|string|null: false|
 |password|string|null: false|
 |e-mail_address|string|priomar_key: false, null: false|
-|message|text||
 ### Association
 has_many :users_groups 
 has_many :groups, through: :users_groups
@@ -39,7 +38,6 @@ has_many :messages
 |Column|Type|Options|
 |------|----|-------|
 |name|string|null: false|
-|message|text|
 ### Association
 has_many :users_groups
 has_many :users, through: :users_groups
@@ -57,11 +55,10 @@ belongs_to :user
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|null: false|
-|group_id| null: false|
-|message|text|null: false|
-|images|references||
-
+|user_id|null: false, false, foreign_key: true|
+|group_id| null: false, false, foreign_key: true|
+|message|text||
+|image|references||
 ### Association
 belongs_to :user
 belongs_to :group

--- a/README.md
+++ b/README.md
@@ -29,22 +29,21 @@ Things you may want to cover:
 |username|string|null: false|
 |password|string|null: false|
 |e-mail_address|string|priomar_key: false, null: false|
-|texts|text||
+|message|text||
 ### Association
-belongs_to :users_groups 
+has_many :users_groups 
 has_many :groups, through: :users_groups
-has_many :messages, through: :users_groups
+has_many :messages
 
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|groupname|string|
-|texts|text||
+|name|string|null: false|
+|message|text|
 ### Association
-belongs_to :users_groups, 
+has_many :users_groups
 has_many :users, through: :users_groups
-has_many :messages, through: :users_groups
-
+has_many :messages
 
 ## users_groupsテーブル
 |Column|Type|Options|
@@ -52,15 +51,17 @@ has_many :messages, through: :users_groups
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 ### Association
-has_many :groups
-has_many :users
+belongs_to :group
+belongs_to :user
 
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|texts|text|null: false|
+|user_id|null: false|
+|group_id| null: false|
+|message|text|null: false|
 |images|references||
-|posttime|datetime|null: false|
+
 ### Association
-belongs_to :users
-belongs_to :groups
+belongs_to :user
+belongs_to :group

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ has_many :messages
 ## users_groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user_id|reference|null: false, foreign_key: true|
+|group_id|reference|null: false, foreign_key: true|
 ### Association
 belongs_to :group
 belongs_to :user
@@ -55,8 +55,8 @@ belongs_to :user
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|null: false, false, foreign_key: true|
-|group_id| null: false, false, foreign_key: true|
+|user_id|reference|null: false, false, foreign_key: true|
+|group_id|reference| null: false, false, foreign_key: true|
 |message|text||
 |image|references||
 ### Association

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ belongs_to :user
 |user_id|reference|null: false, false, foreign_key: true|
 |group_id|reference| null: false, false, foreign_key: true|
 |message|text||
-|image|references||
+|image|string||
 ### Association
 belongs_to :user
 belongs_to :group

--- a/README.md
+++ b/README.md
@@ -26,38 +26,41 @@ Things you may want to cover:
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-username|string|null: false|
-password|string|null: false|
-e-mail_address|string|priomar_key: false, null: false|
-texts|text||
+|username|string|null: false|
+|password|string|null: false|
+|e-mail_address|string|priomar_key: false, null: false|
+|texts|text||
 ### Association
-user belongs_to :groups
-user has_many :messages
+belongs_to :users_groups 
+has_many :groups, through: :users_groups
+has_many :messages, through: :users_groups
 
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-groupname|string|
-texts|text||
+|groupname|string|
+|texts|text||
 ### Association
-group belongs_to :users
-group has_many :messages
+belongs_to :users_groups, 
+has_many :users, through: :users_groups
+has_many :messages, through: :users_groups
 
-## user_groupテーブル
+
+## users_groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 ### Association
-user has many :groups
-group has many :users
+has_many :groups
+has_many :users
 
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-texts|text|null: false|
-images|references||
-posttime|datetime|null: false|
+|texts|text|null: false|
+|images|references||
+|posttime|datetime|null: false|
 ### Association
-message belongs_to :user
-message belongs_to :group
+belongs_to :users
+belongs_to :groups


### PR DESCRIPTION
what :
usersテーブル、groupsテーブル、users_groupsテーブルのアソシエーションを修正。
中間テーブルと各エンティティ（users, groups）の関係を見直し　, through: :users_groups  を追記した。

 why：
以前のレビューで多対多の関係におけるアソシエーションの記載に不備があると指摘頂いたため修正。
中間テーブル（users_groups）と各エンティティをつなげるためのアソシエーションを記載する必要があったため。